### PR TITLE
BLK-223 RestPolling block stops parsing returns after retrying when requ...

### DIFF
--- a/rest/rest_block.py
+++ b/rest/rest_block.py
@@ -140,6 +140,7 @@ class RESTPolling(Block):
 
             # Use the usual retry strategy to resolve the error
             self._retry(None, paging)
+            return
 
         status = resp.status_code
         self.etag = self.etag if paging else resp.headers.get('ETag')


### PR DESCRIPTION
...ests.get fails

Signed-off-by: Oren Leiman oleiman@neutral.io
