### PR TITLE
Closes #32 - only call _locked_poll if there is no retry job

### DIFF
--- a/rest/rest_block.py
+++ b/rest/rest_block.py
@@ -115,7 +115,12 @@ class RESTPolling(Block):
         # Increment the number of lock waiters so we don't build up too many
         self._num_locks += 1
         with self._poll_lock:
-            self._locked_poll(paging)
+            if self._retry_job is None:
+                self._locked_poll(paging)
+            else:
+                self._logger.debug(
+                    "Skipping this poll since a retry job is scheduled"
+                )
         self._num_locks -= 1
 
     def _locked_poll(self, paging=False):


### PR DESCRIPTION
Signed-off-by: Oren Leiman <oleiman@neutral.io>